### PR TITLE
Change VLP(addr) to LP(addr) in DOT spec

### DIFF
--- a/pages/stamps-specifications.vue
+++ b/pages/stamps-specifications.vue
@@ -83,7 +83,7 @@ in order to resolve `hostname`. This is optional, and clients can ignore this in
 Format:
 
 ```text
-"sdns://" || base64url(0x03 || props || VLP(addr) || VLP(hash1, hash2, ...hashn) ||
+"sdns://" || base64url(0x03 || props || LP(addr) || VLP(hash1, hash2, ...hashn) ||
                        LP(hostname) ||
                        [ || vlen(bootstrap_ip) || bootstrap_ip ])
 ```


### PR DESCRIPTION
Hi @jedisct1 !

Am I right that this is a type and you actually wanted to use `LP(addr)` instead of `VLP(addr)` in the spec?

There is no implementation yet so I have to assume. It's just we're going to use stamps in AG for all types of DNS servers, and this seemed strange.