### PR TITLE
Client implementations: RethinkDNS for Android

### DIFF
--- a/pages/implementations.vue
+++ b/pages/implementations.vue
@@ -245,6 +245,15 @@ export default {
           platforms: ["Windows"],
           language: "Closed source",
           description: "An advanced DNS Client for Windows."
+        },
+        {
+          name: "RethinkDNS",
+          Author: "Celzero",
+          url: "https://www.rethinkdns.com/",
+          protocols: ["DNSCrypt"],
+          platforms: ["Android"],
+          language: "Go, Kotlin",
+          description: "A free and open source DNSCrypt v2 client for Android."
         }
       ],
       serverHeaders: [


### PR DESCRIPTION
Hi there, please review.

RethinkDNS is a FOSS client for Android 8+ devices.

Reddit: [r/dnscrypt thread](https://www.reddit.com/r/dnscrypt/comments/jqvq0x/rethinkdns_bravedns_dnscrypt_v2_client_for/).