### PR TITLE
Fix issue where all popups are loading at once

### DIFF
--- a/pages/public-servers.vue
+++ b/pages/public-servers.vue
@@ -15,7 +15,7 @@
       >
         <template slot="items" slot-scope="props">
           <td>
-            <v-dialog v-model="dialog" width="600">
+            <v-dialog width="600">
               <template v-slot:activator="{ on }">
                 <v-badge>
                   <span v-on="on" class="server-name">{{


### PR DESCRIPTION
Closes #33 

It seems the performance issue is from it loading all of the server info popups at once, which is why you can see other modals behind the current dialog. I'm not too familiar with Node or Vue, but it [looks like](https://stackoverflow.com/questions/62076886/vue-vuetify-wrong-index-is-passed-to-v-dialog-when-using-v-for) the `v-model` attribute is really only needed for two-way data binding and can cause this exact issue.